### PR TITLE
Reduce the applyPlayerEffects Mixin for compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version "1.14.6"
+	id 'fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 	id 'com.modrinth.minotaur' version '2.+'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,12 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.2
+yarn_mappings=1.21.11+build.4
+loader_version=0.18.4
 loom_version=1.14-SNAPSHOT
 
 # Fabric API
-fabric_version=0.139.5+1.21.11
+fabric_version=0.141.1+1.21.11
 
 # Mod Properties
 mod_version=1.3.6-21

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,6 @@ loom_version=1.14-SNAPSHOT
 fabric_version=0.141.1+1.21.11
 
 # Mod Properties
-mod_version=1.3.6-21
+mod_version=1.3.7-21
 maven_group=net.unknownuser.beaconrange
 archives_base_name=beaconrange

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/unknownuser/beaconrange/mixins/BeaconMixin.java
+++ b/src/main/java/net/unknownuser/beaconrange/mixins/BeaconMixin.java
@@ -1,11 +1,9 @@
 package net.unknownuser.beaconrange.mixins;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.*;
-import net.minecraft.entity.effect.*;
-import net.minecraft.entity.player.*;
 import net.minecraft.registry.*;
-import net.minecraft.registry.entry.*;
 import net.minecraft.registry.tag.*;
 import net.minecraft.util.*;
 import net.minecraft.util.math.*;
@@ -15,69 +13,16 @@ import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.*;
 
-import java.util.*;
-
 @Mixin(BeaconBlockEntity.class)
 public class BeaconMixin {
 	private BeaconMixin() {}
 	
 	@Unique
 	private static double baseBlockFactor = 1;
-	
-	@Inject(at = @At("HEAD"), method = "applyPlayerEffects", cancellable = true)
-	private static void applyPlayerEffects(
-		World world,
-		BlockPos pos,
-		int beaconLevel,
-		RegistryEntry<StatusEffect> primaryEffect,
-		RegistryEntry<StatusEffect> secondaryEffect,
-		CallbackInfo ci
-	) {
-		// This method is nearly entirely copied from the default implementation, except the range declaration line
-		
-		// replace method entirely
-		ci.cancel();
-		
-		if (!world.isClient() && primaryEffect != null) {
-			double range           = (beaconLevel * Config.rangePerLevel() * baseBlockFactor) + Config.baseOffset(); // CHANGES MADE HERE
-			int    effectAmplifier = 0;
-			
-			if (beaconLevel >= 4 && Objects.equals(primaryEffect, secondaryEffect)) {
-				effectAmplifier = 1;
-			}
-			
-			int                    effectDuration = (9 + beaconLevel * 2) * 20;
-			Box                    rangeBox       = new Box(pos).expand(range).stretch(0.0, world.getHeight(), 0.0);
-			List<PlayerEntity>     players        = world.getNonSpectatingEntities(PlayerEntity.class, rangeBox);
-			Iterator<PlayerEntity> playerIterator = players.iterator();
-			
-			PlayerEntity playerEntity;
-			while (playerIterator.hasNext()) {
-				playerEntity = playerIterator.next();
-				playerEntity.addStatusEffect(new StatusEffectInstance(
-					primaryEffect,
-					effectDuration,
-					effectAmplifier,
-					true,
-					true
-				));
-			}
-			
-			if (beaconLevel >= 4 && !Objects.equals(primaryEffect, secondaryEffect) && secondaryEffect != null) {
-				playerIterator = players.iterator();
-				
-				while (playerIterator.hasNext()) {
-					playerEntity = playerIterator.next();
-					playerEntity.addStatusEffect(new StatusEffectInstance(
-						secondaryEffect,
-						effectDuration,
-						0,
-						true,
-						true
-					));
-				}
-			}
-		}
+
+	@ModifyVariable(method = "applyPlayerEffects", at = @At("STORE"))
+	private static double applyNewBeaconRange(double range, @Local(argsOnly = true) int beaconLevel) {
+		return (beaconLevel * Config.rangePerLevel() * baseBlockFactor) + Config.baseOffset();
 	}
 	
 	@Inject(at = @At("HEAD"), method = "updateLevel", cancellable = true)


### PR DESCRIPTION
This PR attempts to maximise the compatibility of the mod by reducing the impact the `applyPlayerEffects` Mixin has over the vanilla method. Instead of cancelling and replacing the entire method, this change will just apply the new beacon range calculation over the `double range` declaration near the beginning of the method.

This change over vanilla ends up looking like this:

``` diff
- double d = beaconLevel * 10 + 10; // vanilla
+ double d = (beaconLevel * Config.rangePerLevel() * baseBlockFactor) + Config.baseOffset(); // mod
```

This should achieve the same result as what the mod currently does, but keeps the rest of the method compatible with other mods that want to Mixin to the same method. I have a mod called [BeaconSaturation](https://modrinth.com/mod/beaconsaturation) that attempts to Mixin to this method but that won't happen if it's replaced - this fixes that and makes them compatible again.

I attempted to do the same, and slimline the `updateLevel` mixin to be as compatible with other mods too, but the approach was brittle and the logic is a little too complex to handle gracefully, so I stuck with the above change only.

I also updated the gradle wrapper version in `gradle-wrapper.properties` to be able to build the mod locally - this should also fix the [failing action](https://github.com/Callisto95/BeaconRangeExtender/actions/runs/20316906785) from the last PR.